### PR TITLE
Let button rows wrap so the app can be used on small screens

### DIFF
--- a/src/screens/FlashCards.css
+++ b/src/screens/FlashCards.css
@@ -10,6 +10,7 @@
 
 .DeckSelection {
   display: flex;
+  flex-wrap: wrap;
 }
 
 .FlashCard > * {
@@ -44,6 +45,7 @@
 .AllDecksOptions > *,
 .SingleDeckTypeOptions > * {
   display: flex;
+  flex-wrap: wrap;
   margin: 10px;
   justify-content: center;
 }


### PR DESCRIPTION
After I browsed to this repository, I was curious how this app handled small screens. After I saw the app refuse to shrink to the width of the window, I knew the cause, so I thought I’d suggest a fix.

Disclaimer: I did not test these changes by building the app. I only tested by adding the CSS in Chrome’s Developer Tools and seeing how it looked.

## Before

![music before wrapping](https://user-images.githubusercontent.com/79168/147865677-86617cfe-0502-4c71-83a2-99abdaa8f522.png)

## After

![music after wrapping](https://user-images.githubusercontent.com/79168/147865680-de806350-d87d-4731-a91d-b54d02687b82.png)
